### PR TITLE
Added multi function

### DIFF
--- a/StoryCog.py
+++ b/StoryCog.py
@@ -150,6 +150,49 @@ class StoryCog(commands.Cog):
     async def clearproxy(self, ctx: commands.Context):
         if ctx.author.id in self.proxies:
             self.proxies.pop(ctx.author.id)
+
+    @commands.command(ignore_extra=False)
+    async def multi(self, ctx: commands.Context, *args) -> None:
+        """ Runs multiple commands from one message """
+
+        names_to_funcs = {
+                "addstory":self.addstory,
+                "removestory":self.removestory,
+                "settitle":self.settitle,
+                "addgenre":self.addgenre,
+                "removegenre":self.removegenre,
+                "setrating":self.setrating,
+                "setratingreason":self.setratingreason,
+                "addcharacter":self.addcharacter,
+                "removecharacter":self.removecharacter,
+                "setsummary":self.setsummary,
+                "addlink":self.addlink,
+                "removelink":self.removelink
+                }
+
+        def clean_up_args(args):
+            ret = []
+            for arg in args:
+                if "=" in arg:
+                    ret.append(arg)
+                    continue
+                ret[-1] = ret[-1] + " " + arg
+            return ret
+
+        args = clean_up_args(args)
+
+        for arg in args:
+            func_name, sub_args = arg.split("=")
+            try:
+                func = names_to_funcs[func_name]
+            except KeyError:
+                await dmError(ctx, f"No function '{func_name}' (did you mistype?)")
+                continue
+            if func_name == "addlink":
+                link_name, link = sub_args.split(" ")
+                await func(ctx, link_name, link)
+                continue
+            await func(ctx, sub_args)
     
     @commands.command(ignore_extra=False)
     @commands.cooldown(1, 8 * 60, commands.BucketType.guild)


### PR DESCRIPTION
Added a command called "multi" to run multiple commands with one message. For example, posting the following in Discord (as a single message):

> lap.multi
> addstory=TEST
> addgenre=adventure
> setrating=M
> setratingreason=it is a very edgy story
> addcharacter=Oli
> setsummary=This is my summary
> addlink=AO3 my-a03-link

would create a story called "TEST", add the "adventure" genre to it, set the rating to "M", set the rating reason to "it is a very edgy story", add the character "Oli", set the summary to "This is my summary", and add an AO3 link "my-ao3-link"

The advantage to this would be that you can use the above, or something similar, as a nice template that users can edit and then use to post their story all in one go. Personally, I just think it would be much more convenient.

This is kinda getting into implementation details a bit, but the function "clean_up_args" (to which I forgot to add type hints... oops) is there to combine sub-arguments that have spaces. For example, your summary will probably have spaces, but we don't want to treat each word in the summary as a separate argument because that will clearly just break everything. So, following the above example, "clean_up_args" would get an input of: 

('addstory=TEST', 'addgenre=adventure', 'setrating=M', 'setratingreason=it', 'is', 'a', 'very', 'edgy', 'story', 'summary=This', 'is', 'my', 'summary')

and it would return:

['addstory=TEST', 'addgenre=adventure', 'setrating=M', 'setratingreason=it is a very edgy story', 'summary=This is my summary']

which we can work with. Though the function is reasonably concise, it is perhaps a little bit hacky. Maybe there's a better solution.

Message me if you wanna chat about it. Feel free to rename as you see fit or whatever; not sure if "multi" is necessarily the best name for the function, nor am I sure the "remove" commands should be included in it, but it's up to you.