### PR TITLE
Shorten Vertical Use of Story Stuff

### DIFF
--- a/Archive.py
+++ b/Archive.py
@@ -119,12 +119,10 @@ class Story(Prioritied):
         linksStr = "\n".join([f"- {link.siteAbbr}: <{link.url}>" for link in sorted(self.links, key=Prioritied.key)])
         
         string = "" + \
-            f"**Title**: {self.title}\n" + \
-            f"**Genres**: {genresStr}\n" + \
-            f"**Rating**: {ratingStr}\n" + \
-            f"**Main Characters**: {charsStr}\n" + \
-            f"**Summary**:\n{summaryStr}\n" + \
-            f"**Links**:\n{linksStr}"
+            f"**{self.title}** [{ratingStr}]\n" + \
+            f"Main Characters: {charsStr}\n" + \
+            f"{summaryStr}\n" + \
+            f"{linksStr}"
         return string
     
     def cite(self):


### PR DESCRIPTION
Further ways to shorten this could include changing "@lapras \n Null Protocol" to "Null Protocol by @lapras", and removing the five trailing dashes (seems no longer needed now that pagination is used to store multiple stories?) I feel like genre isn't that needed, especially given how much is "Adventure, Friendship"